### PR TITLE
Refactor RedirectService::addRedirect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RedirectMate Changelog
 
+## Unreleased
+### Improved
+- RedirectMate is now smarter about how conflicting redirects are handled when saving a new redirect, or editing an existing one.
+
 ## 1.0.3 - 2024-03-03
 ### Fixed
 - Fixed an issue where it wasn't possible to change the site when editing an existing redirect  


### PR DESCRIPTION
Refactors how existing redirects are handled when adding new redirects (or editing existing ones):

- Existing redirects are never updated, only deleted, if the redirect being added (or edited) has the same `siteId` (or a `null` siteId) as the existing one
- If an existing redirect has the same `sourceUrl`, but a different siteId from the redirect being saved, it's left alone
- In querying for existing or conflicting redirects when saving an edited redirect, the `id` param is added to the queries

This solves some unexpected behaviours when adding new redirects or editing existing ones.